### PR TITLE
fix: don't set gui stuff for vimr

### DIFF
--- a/autoload/thematic.vim
+++ b/autoload/thematic.vim
@@ -235,7 +235,7 @@ function! thematic#init(mode) abort
 
   " ------ Set GUI-only settings ------
 
-  if l:gui_running
+  if l:gui_running && !has("gui_vimr")
     call thematic#gui#init(l:th)
   endif
 


### PR DESCRIPTION
vimr has gui_running but doesn't have guifont, so it triggers a bunch of errors with thematic on itit.